### PR TITLE
Added log/trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ packets are received. This makes `nfqlb` scalable.
 * [SCTP](sctp.md) - SCTP load-balancing with multihoming
 * [extend/alter](src/README.md) - Extend or alter `nfqlb`
 * [Flows](flow.md) - Define LBs for flows, (proto,src,dst,sport,dport) tuples
+* [Log/trace](log-trace.md) - Log and trace
 
 ## Try it
 

--- a/log-trace.md
+++ b/log-trace.md
@@ -1,0 +1,89 @@
+# Nordix/nfqueue-loadbalancer - Log and trace
+
+Log and trace is supported but affects performance and should be used
+with care.
+
+
+## Log
+
+Logs printouts are printed to `stderr`.
+
+Log levels;
+
+* `WARNING` (4) - Important events
+* `NOTICE` (5) - Notable events (default)
+* `INFO` (6) - Informative events
+* `DEBUG` (7) - Debug events
+
+If traffic is working there should not be any per-packet loggings even
+on `debug` level.
+
+The loglevel is stored in shared memory which make it possible to set
+it in runtime with the `nfqlb loglevel` command;
+
+```
+# nfqlb loglevel
+loglevel=5
+# nfqlb loglevel 7
+loglevel=7
+# nfqlb loglevel
+loglevel=7
+```
+
+
+## Trace
+
+Trace is independent of the loglevel, that is trace is not loglevel>7.
+Trace is based on a 32-bit "trace mask". Each bit represent a trace
+area;
+
+* `log` (0) - Log printouts are copied to trace printouts
+* `packet` (1) - Per-packet printouts. Use with care!
+* `frag` (2) - Fragment tracing. Per-fragment printouts
+* `flow-conf` (3) - Flow configuration printouts
+* `sctp` (4) - Per-packet sctp printouts
+* `target` (5) - Trace flow target add/release (not per-packet)
+
+
+To initiate trace you attach to a running `nfqlb` load-balancer with
+`nfqlb trace`. Printouts goes to `stdout`;
+
+```
+nfqlb trace --selection=log,packet,frag
+# Or;
+nfqlb trace --mask=0xffffffff   # trace everything
+```
+
+
+## Trace-flows
+
+**Not yet implemented** (but shoudn't be to hard)
+
+Per-packet printouts should normally be avoided but may sometimes be
+necessary. The flows in `nfqlb` are re-use to select packets to
+trace. The flow commands are be duplicated, like;
+
+```
+  trace-flow-set
+  trace-flow-delete
+  trace-flow-list
+```
+
+And per-packet printouts only for packets that matches the trace-flows
+can be initated with;
+
+```
+nfqlb trace --selection=flows,...
+```
+
+
+## Compile without log/trace
+
+There is always a fear that the even if nothing is logged or traced
+the numerous checks in the code will affect performance. For tests
+log/trace can be disabled;
+
+```
+make clean
+CFLAGS=-DNO_LOG make -j8
+```

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -1,0 +1,149 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2022 Nordix Foundation
+*/
+#ifndef NO_LOG
+
+#include <log.h>
+#include <die.h>
+#include <shmem.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <stddef.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <signal.h>
+
+static struct LogConfig default_config = {5, 0};
+struct LogConfig* logconfig = &default_config;
+FILE* logfile = NULL;
+static FILE* tracefile = NULL;
+
+static pthread_mutex_t tlock = PTHREAD_MUTEX_INITIALIZER;
+#define LOCK() pthread_mutex_lock(&tlock)
+#define UNLOCK() pthread_mutex_unlock(&tlock)
+
+int tracef(const char *fmt, ...)
+{
+	LOCK();
+	if (tracefile == NULL) {
+		UNLOCK();
+		return 0;
+	}
+	va_list ap;
+	va_start(ap, fmt);
+	int rc = vfprintf(tracefile, fmt, ap);
+	va_end(ap);
+	UNLOCK();
+	return rc;
+}
+
+int logp(const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	int rc = vfprintf(logfile, fmt, ap);
+	va_end(ap);
+
+	if (tracefile == NULL || (logconfig->tracemask & TRACE_LOG) == 0)
+		return rc;
+
+	// Log trace is active
+	LOCK();
+	if (tracefile == NULL) {
+		UNLOCK();
+		return 0;
+	}
+	va_start(ap, fmt);
+	vfprintf(tracefile, fmt, ap);
+	va_end(ap);
+	UNLOCK();
+	return rc;
+}
+
+
+
+void logConfigShm(char const* name)
+{
+	logconfig = mapSharedData(name, O_RDWR);
+	if (logconfig != NULL)
+		return;
+	createSharedDataOrDie(name, &default_config, sizeof(struct LogConfig));
+	logconfig = mapSharedDataOrDie(name, O_RDWR);
+}
+
+__attribute__ ((__constructor__)) static void loginit(void) {
+	logfile = stderr;
+	tracefile = stderr;
+}
+
+
+static void* traceServerThread(void* arg)
+{
+	info("Started Trace\n");
+	int sd = socket(AF_LOCAL, SOCK_STREAM, 0);
+	struct sockaddr_un sa;
+	sa.sun_family = AF_UNIX;
+	sa.sun_path[0] = 0;
+	char const* unix_socket = arg;
+	strcpy(sa.sun_path+1, unix_socket);
+	socklen_t len =
+		offsetof(struct sockaddr_un, sun_path) + strlen(sa.sun_path+1) + 1;
+	if (bind(sd, (struct sockaddr*)&sa, len) != 0)
+		die("bind\n");
+	if (listen(sd, 1) != 0)
+		die("listen\n");
+	for (;;) {
+		debug("Trace: accept\n");
+		int cd = accept(sd, NULL, NULL);
+		info("Trace; Accepted incoming connection. cd=%d\n", cd);
+		if (cd < 0) {
+			warning("Trace: accept returns %d\n", cd);
+			continue;
+		}
+		LOCK();
+		tracefile = fdopen(cd, "w");
+		if (tracefile == NULL) {
+			UNLOCK();
+			warning("Trace: fdopen failed\n");
+			close(cd);
+			continue;
+		}
+		setlinebuf(tracefile);
+		UNLOCK();
+
+		warning("Trace; active mask=0x%08x\n", logconfig->tracemask);
+		tracef("Trace active, mask=0x%08x\n", logconfig->tracemask);
+
+		// Any input should be a shutdown
+		signal(SIGPIPE, SIG_IGN); /* (see comment below) */
+		char buffer[254];
+		(void)read(cd, buffer, sizeof(buffer));
+		/*
+		  Precisely *here* the "cd" file descriptor is closed by the peer.
+		  If a thread writes to "tracefile" a SIGPIPE is generated.
+		  The default action is to terminate the process. Not good!
+		*/
+		tracef("SIGPIPE TEST\n");
+		logconfig->tracemask = 0;
+
+		LOCK();
+		fclose(tracefile);
+		tracefile = NULL;
+		close(cd);
+		UNLOCK();
+		signal(SIGPIPE, SIG_DFL);
+		warning("Trace: closed\n");
+	}
+	return NULL;
+}
+
+void logTraceServer(char const* unix_socket) {
+	pthread_t tid;
+	if (pthread_create(&tid, NULL, traceServerThread, (void*)unix_socket) != 0)
+		die("\n");
+}
+
+#endif

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -1,0 +1,64 @@
+#pragma once
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2022 Nordix Foundation
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+
+#ifndef NO_LOG
+struct LogConfig {
+	int level;
+	uint32_t tracemask;
+};
+extern struct LogConfig* logconfig;
+extern FILE* logfile;
+
+#define LOG_LEVEL logconfig->level
+#define LOG_SET_LEVEL(x) logconfig->level = x
+#define LOG_SET_TRACE_MASK(x) logconfig->tracemask = x
+
+// Re-map the LogConfig to shared memory.
+// This allows log and trace to be controlled in runtime.
+void logConfigShm(char const* name);
+
+// Start the trace server thread
+void logTraceServer(char const* unix_socket);
+
+#define WARNING if(logconfig->level>=4)
+#define NOTICE if(logconfig->level>=5)
+#define INFO if(logconfig->level>=6)
+#define DEBUG if(logconfig->level>=7)
+#define warning(arg...) WARNING{logp(arg);}
+#define notice(arg...) NOTICE{logp(arg);}
+#define info(arg...) INFO{logp(arg);}
+#define debug(arg...) DEBUG{logp(arg);}
+int logp(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+
+#define TRACE_LOG		1
+#define TRACE(m) if((logconfig->tracemask & (m)) != 0)
+#define trace(m,arg...) TRACE(m){tracef(arg);}
+int tracef(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
+
+#else
+// Log/trace can be disabled for performance reasons/tests.
+#define logConfigShm(x)
+#define logTraceServer(x)
+#define LOG_LEVEL -1
+#define LOG_SET_LEVEL(x)
+#define LOG_SET_TRACE_MASK(x)
+#define WARNING if(0)
+#define NOTICE if(0)
+#define INFO if(0)
+#define DEBUG if(0)
+#define logp(arg...)
+#define warning(arg...)
+#define notice(arg...)
+#define info(arg...)
+#define debug(arg...)
+
+#define TRACE(m) if(0)
+#define tracef(arg...)
+#define trace(m,arg...)
+#endif

--- a/src/nfqlb/cmdTrace.c
+++ b/src/nfqlb/cmdTrace.c
@@ -1,0 +1,120 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2022 Nordix Foundation
+*/
+#define _GNU_SOURCE
+#include <cmd.h>
+#include <die.h>
+#include <log.h>
+#include "trace.h"
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+static unsigned str2mask(char const* name)
+{
+	static const struct TraceEvent {
+		char const* name;
+		unsigned mask;
+	} traceEvent[] = {
+		{"log", TRACE_LOG},
+		{"packet", TRACE_PACKET},
+		{"frag", TRACE_FRAG},
+		{"flow-conf", TRACE_FLOW_CONF},
+		{"sctp", TRACE_SCTP},
+		{"target", TRACE_TARGET},
+		{NULL, 0}	
+	};
+
+	struct TraceEvent const* e;
+	for (e = traceEvent; e->name != NULL; e++) {
+		if (strcmp(name, e->name) == 0)
+			return e->mask;
+	}
+	return 0;
+}
+
+
+static int cmdTrace(int argc, char **argv)
+{
+	char const* traceMaskOpt = NULL;
+	char const* traceSelectionOpt = NULL;
+	struct Option options[] = {
+		{"help", NULL, 0,
+		 "trace [options]\n"
+		 "  Initiate trace and direct output to stdout"},
+		{"mask", &traceMaskOpt, 0, "Trace mask (32-bit). Most for debug"},
+		{"selection", &traceSelectionOpt, 0,
+		 "Trace selection. A comma separated list of;\n"
+		 "     log,packet,frag,flow-conf,sctp,target"},
+		{0, 0, 0, 0}
+	};
+	(void)parseOptionsOrDie(argc, argv, options);
+	if (traceMaskOpt == NULL && traceSelectionOpt == NULL)
+		die("Specify any of --mask or --selection");
+	if (traceMaskOpt != NULL && traceSelectionOpt != NULL)
+		die("Specify any ONE of --mask or --selection");
+
+	uint32_t mask = 0;
+	if (traceSelectionOpt != NULL) {
+		char* sel = strdupa(traceSelectionOpt);
+		char* t;
+		for (t = strtok(sel, ","); t != NULL; t = strtok(NULL, ",")) {
+			mask |= str2mask(t);
+		}
+	} else {
+		mask = strtol(traceMaskOpt, NULL, 0);
+	}
+	printf("Mask=0x%08x\n", mask);
+
+	logConfigShm(TRACE_SHM);
+	LOG_SET_TRACE_MASK(mask);
+
+	int sd = socket(AF_LOCAL, SOCK_STREAM, 0);
+	struct sockaddr_un sa = {0};
+	sa.sun_family = AF_UNIX;
+	sa.sun_path[0] = 0;
+	strcpy(sa.sun_path+1, TRACE_UNIX_SOCK);
+	socklen_t len =
+		offsetof(struct sockaddr_un, sun_path) + strlen(sa.sun_path+1) + 1;
+	if (connect(sd, (struct sockaddr*)&sa, len) != 0)
+		die("FAILED: connect\n");
+
+	char buffer[4*1024];
+	int rc = read(sd, buffer, sizeof(buffer));
+	while (rc > 0) {
+		if (write(1, buffer, rc) != rc)
+			die("FAILED: write\n");
+		rc = read(sd, buffer, sizeof(buffer));
+	}
+
+	return 0;
+}
+
+static int cmdLoglevel(int argc, char **argv)
+{
+	struct Option options[] = {
+		{"help", NULL, 0,
+		 "loglevel [level]\n"
+		 "  Set log level in shared mem"},
+		{0, 0, 0, 0}
+	};
+	int nopt = parseOptionsOrDie(argc, argv, options);
+	argc -= nopt; argv += nopt;
+
+	logConfigShm(TRACE_SHM);
+	if (argc > 0)
+		LOG_SET_LEVEL(atoi(argv[0]));
+
+	printf("loglevel=%d\n", LOG_LEVEL);
+	return 0;
+}
+
+__attribute__ ((__constructor__)) static void addCommands(void) {
+	addCmd("trace", cmdTrace);
+	addCmd("loglevel", cmdLoglevel);
+}
+

--- a/src/nfqlb/trace.h
+++ b/src/nfqlb/trace.h
@@ -1,0 +1,14 @@
+#pragma once
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2022 Nordix Foundation
+*/
+
+#define TRACE_PACKET	2
+#define TRACE_FRAG		4
+#define TRACE_FLOW_CONF	8
+#define TRACE_SCTP		16
+#define TRACE_TARGET	32
+
+#define TRACE_SHM "nfqlb-trace"
+#define TRACE_UNIX_SOCK "nfqlb-trace"


### PR DESCRIPTION
Add log with the traditional levels. Default level is `WARNING`. Even on `debug` level there should be no "per packet" printouts in normal traffic cases (load-balancing working).

Trace is independent from the log-level, that is, you will not get log-level>=debug by turning on trace. Trace is controlled by a 32-bit mask and may cause per-packet printouts.
