### PR TITLE
Add possibility to specify trace_address socket

### DIFF
--- a/src/nfqlb/cmdFlowLb.c
+++ b/src/nfqlb/cmdFlowLb.c
@@ -241,6 +241,7 @@ static int cmdFlowLb(int argc, char **argv)
 	char const* promiscuous_ping = "no";
 	char const* notargets_fwmark = "-1";
 	char const* nolb_fwmark = "-1";
+	char const* trace_address = DEFAULT_TRACE_ADDRESS;
 	struct Option options[] = {
 		{"help", NULL, 0,
 		 "flowlb [options]\n"
@@ -260,11 +261,12 @@ static int cmdFlowLb(int argc, char **argv)
 		{"ft_buckets", &ft_buckets, 0, "Frag table; extra buckets"},
 		{"ft_frag", &ft_frag, 0, "Frag table; stored frags"},
 		{"ft_ttl", &ft_ttl, 0, "Frag table; ttl milliS"},
+		{"trace_address",  &trace_address, 0, "Trace server address"},
 		{0, 0, 0, 0}
 	};
 	(void)parseOptionsOrDie(argc, argv, options);
 	logConfigShm(TRACE_SHM);
-	logTraceServer(DEFAULT_TRACE_ADDRESS);
+	logTraceServer(trace_address);
 
 	if (lbShm != NULL) {
 		slb = mapSharedDataOrDie(lbShm, O_RDONLY);

--- a/src/nfqlb/cmdLb.c
+++ b/src/nfqlb/cmdLb.c
@@ -135,6 +135,7 @@ static int cmdLb(int argc, char **argv)
 	char const* reassembler = "0";
 	char const* sctpEncap = "0";
 	char const* notargets_fwmark = "-1";
+	char const* trace_address = DEFAULT_TRACE_ADDRESS;
 	struct Option options[] = {
 		{"help", NULL, 0,
 		 "lb [options]\n"
@@ -153,11 +154,12 @@ static int cmdLb(int argc, char **argv)
 		{"ft_buckets", &ft_buckets, 0, "Frag table; extra buckets"},
 		{"ft_frag", &ft_frag, 0, "Frag table; stored frags"},
 		{"ft_ttl", &ft_ttl, 0, "Frag table; ttl milliS"},
+		{"trace_address",  &trace_address, 0, "Trace server address"},
 		{0, 0, 0, 0}
 	};
 	(void)parseOptionsOrDie(argc, argv, options);
 	logConfigShm(TRACE_SHM);
-	logTraceServer(DEFAULT_TRACE_ADDRESS);
+	logTraceServer(trace_address);
 
 	st = mapSharedDataOrDie(targetShm, O_RDONLY);
 	magDataDyn_map(&magd, st->mem);

--- a/src/nfqlb/cmdTrace.c
+++ b/src/nfqlb/cmdTrace.c
@@ -39,6 +39,7 @@ static int cmdTrace(int argc, char **argv)
 {
 	char const* traceMaskOpt = NULL;
 	char const* traceSelectionOpt = NULL;
+	char const* trace_address = DEFAULT_TRACE_ADDRESS;
 	struct Option options[] = {
 		{"help", NULL, 0,
 		 "trace [options]\n"
@@ -47,6 +48,7 @@ static int cmdTrace(int argc, char **argv)
 		{"selection", &traceSelectionOpt, 0,
 		 "Trace selection. A comma separated list of;\n"
 		 "     log,packet,frag,flow-conf,sctp,target,flows"},
+		{"trace_address", &trace_address, 0, "Trace server address"},
 		{0, 0, 0, 0}
 	};
 	(void)parseOptionsOrDie(argc, argv, options);
@@ -72,15 +74,14 @@ static int cmdTrace(int argc, char **argv)
 
 	struct sockaddr_storage sa;
 	socklen_t len;
-	char const* addr = DEFAULT_TRACE_ADDRESS;
-	if (parseAddress(addr, &sa, &len) != 0)
-		die("Failed to parse address [%s]", addr);
+	if (parseAddress(trace_address, &sa, &len) != 0)
+		die("Failed to parse address [%s]", trace_address);
 	
 	int sd = socket(sa.ss_family, SOCK_STREAM, 0);
 	if (sd < 0)
 		die("Trace client socket: %s\n", strerror(errno));
 	if (connect(sd, (struct sockaddr*)&sa, len) != 0)
-		die("Trace client connect to %s: %s\n", addr, strerror(errno));
+		die("Trace client connect to %s: %s\n", trace_address, strerror(errno));
 
 	char buffer[4*1024];
 	int rc = read(sd, buffer, sizeof(buffer));


### PR DESCRIPTION
When starting multiple nfqlb processes, trace server must be started on different unix sockets. This PR adds the possiblity to specify a trace address other than the default value.