### PR TITLE
Validate maglev shm

### DIFF
--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -66,11 +66,11 @@ int logp(const char *fmt, ...)
 
 void logConfigShm(char const* name)
 {
-	logconfig = mapSharedData(name, O_RDWR);
+	logconfig = mapSharedData(name, O_RDWR, NULL);
 	if (logconfig != NULL)
 		return;
 	createSharedDataOrDie(name, &default_config, sizeof(struct LogConfig));
-	logconfig = mapSharedDataOrDie(name, O_RDWR);
+	logconfig = mapSharedDataOrDie(name, O_RDWR, NULL);
 }
 
 __attribute__ ((__constructor__)) static void loginit(void) {

--- a/src/lib/maglevdyn.c
+++ b/src/lib/maglevdyn.c
@@ -50,6 +50,30 @@ void magDataDyn_init(unsigned M, unsigned N, void* mem, unsigned len)
 	magDataDyn_free(&m);
 }
 
+int magDataDyn_validate(void* mem, size_t len)
+{
+	if (len < sizeof(struct MagDataDynInternal))
+		return -1;
+	struct MagDataDynInternal* mi = mem;
+	// M and N may be mutating in shm so copy them ASAP
+	unsigned M, N;
+	M = mi->M;
+	N = mi->N;
+	if (M < 3)
+		return -1;
+	return 0;
+	if (N == 0)
+		return -1;
+	if (N > M)
+		return -1;
+	if (M != primeBelow(M))
+		return -1;
+	// len may be higher, but this validation is stricter
+	if (len != magDataDyn_len(M, N))
+		return -1;
+	return 0;
+}
+
 void magDataDyn_map(struct MagDataDyn* m, void* mem)
 {
 	struct MagDataDynInternal* mi = mem;

--- a/src/lib/maglevdyn.h
+++ b/src/lib/maglevdyn.h
@@ -1,4 +1,10 @@
+/*
+   SPDX-License-Identifier: Apache-2.0
+   Copyright (c) 2021-2022 Nordix Foundation
+*/
 #pragma once
+
+#include <stddef.h>
 
 struct MagDataDyn {
 	unsigned M, N;
@@ -19,6 +25,11 @@ unsigned magDataDyn_len(unsigned M, unsigned N);
   Prerequisite; mem allocated and len >= returned by magDataDyn_len()
  */
 void magDataDyn_init(unsigned M, unsigned N, void* mem, unsigned len);
+
+/*
+  Validate that a memory area is MagDataDyn compatible
+*/
+int magDataDyn_validate(void* mem, size_t len);
 
 /*
   Map to a memory area that may be in shared mem.

--- a/src/lib/shmem.h
+++ b/src/lib/shmem.h
@@ -9,7 +9,7 @@
 
 int createSharedData(char const* name, void* data, size_t len);
 void createSharedDataOrDie(char const* name, void* data, size_t len);
-void* mapSharedData(char const* name, int mode);
-void* mapSharedDataOrDie(char const* name, int mode);
-void* mapSharedDataRead(char const* name, /*out*/int* fd);
+void* mapSharedData(char const* name, int mode, size_t* len);
+void* mapSharedDataOrDie(char const* name, int mode, size_t* len);
+void* mapSharedDataRead(char const* name, /*out*/int* fd, size_t* len);
 

--- a/src/nfqlb/cmdConfig.c
+++ b/src/nfqlb/cmdConfig.c
@@ -29,7 +29,10 @@ static int cmdActivate(int argc, char **argv)
 	argc -= nopt;
 	argv += nopt;
 	struct SharedData* s;
-	s = mapSharedDataOrDie(shm, O_RDWR);
+	size_t len;
+	s = mapSharedDataOrDie(shm, O_RDWR, &len);
+	if (magDataDyn_validate(s->mem, len - sizeof(struct SharedData)) != 0)
+		die("Shm invalid; %s\n", shm);
 	struct MagDataDyn magd;
 	magDataDyn_map(&magd, s->mem);
 
@@ -88,7 +91,10 @@ static int cmdDeactivate(int argc, char **argv)
 	argc -= nopt;
 	argv += nopt;
 	struct SharedData* s;
-	s = mapSharedDataOrDie(shm, O_RDWR);
+	size_t len;
+	s = mapSharedDataOrDie(shm, O_RDWR, &len);
+	if (magDataDyn_validate(s->mem, len - sizeof(struct SharedData)) != 0)
+		die("Shm invalid; %s\n", shm);
 	struct MagDataDyn magd;
 	magDataDyn_map(&magd, s->mem);
 

--- a/src/nfqlb/cmdFlowLb-test.c
+++ b/src/nfqlb/cmdFlowLb-test.c
@@ -222,7 +222,7 @@ static void initShm(
 	s->ownFwmark = ownFw;
 	createSharedDataOrDie(name, s, sizeof(struct SharedData) + len);
 	free(s);
-	s = mapSharedDataOrDie(name, O_RDWR);
+	s = mapSharedDataOrDie(name, O_RDWR, NULL);
 	magDataDyn_init(m, n, s->mem, len);
 }
 

--- a/src/nfqlb/cmdFlowLb.c
+++ b/src/nfqlb/cmdFlowLb.c
@@ -279,7 +279,7 @@ static int cmdFlowLb(int argc, char **argv)
 	logTraceServer(trace_address);
 
 	if (lbShm != NULL) {
-		slb = mapSharedDataOrDie(lbShm, O_RDONLY);
+		slb = mapSharedDataOrDie(lbShm, O_RDONLY, NULL);
 		magDataDyn_map(&magdlb, slb->mem);
 	}
 
@@ -296,7 +296,7 @@ static int cmdFlowLb(int argc, char **argv)
 	sft = calloc(1, sizeof(*sft));
 	createSharedDataOrDie(ftShm, sft, sizeof(*sft));
 	free(sft);
-	sft = mapSharedDataOrDie(ftShm, O_RDWR);
+	sft = mapSharedDataOrDie(ftShm, O_RDWR, NULL);
 
 	// Get MTU from the ingress device
 	int mtu = atoi(mtuOpt);
@@ -432,12 +432,19 @@ STATIC struct LoadBalancer* loadbalancerFindOrCreate(char const* target)
 	// Not found, create a new LB
 	trace(TRACE_TARGET, "Creating LB; %s\n", target);
 	int fd;
-	struct SharedData* st = mapSharedDataRead(target, &fd);
+	size_t len;
+	struct SharedData* st = mapSharedDataRead(target, &fd, &len);
 	if (st == NULL) {
 		UNLOCK(lblistLock);
 		trace(TRACE_TARGET, "Map shm failed; %s\n", target);
 		return NULL;
 	}
+	if (magDataDyn_validate(st->mem, len - sizeof(struct SharedData)) != 0) {
+		UNLOCK(lblistLock);
+		trace(TRACE_TARGET, "Shm invalid; %s\n", target);
+		return NULL;
+	}
+
 
 	lb = MALLOC(lb);
 	lb->target = strdup(target);

--- a/src/nfqlb/cmdFwmark.c
+++ b/src/nfqlb/cmdFwmark.c
@@ -60,7 +60,7 @@ static int cmdFwmark(int argc, char **argv)
 
 	if (shm != NULL) {
 		struct SharedData* s = NULL;
-		s = mapSharedDataOrDie(shm, O_RDWR);
+		s = mapSharedDataOrDie(shm, O_RDWR, NULL);
 		struct MagDataDyn magd;
 		magDataDyn_map(&magd, s->mem);
 		unsigned index = hash % magd.M;

--- a/src/nfqlb/cmdLb.c
+++ b/src/nfqlb/cmdLb.c
@@ -161,10 +161,10 @@ static int cmdLb(int argc, char **argv)
 	logConfigShm(TRACE_SHM);
 	logTraceServer(trace_address);
 
-	st = mapSharedDataOrDie(targetShm, O_RDONLY);
+	st = mapSharedDataOrDie(targetShm, O_RDONLY, NULL);
 	magDataDyn_map(&magd, st->mem);
 	if (lbShm != NULL) {
-		slb = mapSharedDataOrDie(lbShm, O_RDONLY);
+		slb = mapSharedDataOrDie(lbShm, O_RDONLY, NULL);
 		magDataDyn_map(&magdlb, slb->mem);
 	}
 	notargets_fw = atoi(notargets_fwmark);
@@ -173,7 +173,7 @@ static int cmdLb(int argc, char **argv)
 	sft = calloc(1, sizeof(*sft));
 	createSharedDataOrDie(ftShm, sft, sizeof(*sft));
 	free(sft);
-	sft = mapSharedDataOrDie(ftShm, O_RDWR);
+	sft = mapSharedDataOrDie(ftShm, O_RDWR, NULL);
 
 	// Get MTU from the ingress device
 	int mtu = atoi(mtuOpt);

--- a/src/nfqlb/cmdShm.c
+++ b/src/nfqlb/cmdShm.c
@@ -27,7 +27,7 @@ static void initShm(
 	s->ownFwmark = ownFw;
 	createSharedDataOrDie(name, s, sizeof(struct SharedData) + len);
 	free(s);
-	s = mapSharedDataOrDie(name, O_RDWR);
+	s = mapSharedDataOrDie(name, O_RDWR, NULL);
 	magDataDyn_init(m, n, s->mem, len);
 }
 
@@ -109,7 +109,10 @@ static int cmdShow(int argc, char **argv)
 	};
 	(void)parseOptionsOrDie(argc, argv, options);
 	struct SharedData* s;
-	s = mapSharedDataOrDie(shm, O_RDONLY);
+	size_t len;
+	s = mapSharedDataOrDie(shm, O_RDONLY, &len);
+	if (magDataDyn_validate(s->mem, len - sizeof(struct SharedData)) != 0)
+		die("Shm invalid; %s\n", shm);
 	if (s == NULL)
 		die("Failed to open shared mem; %s\n", shm);
 	printf("Shm: %s\n", shm);
@@ -144,7 +147,7 @@ static int cmdStats(int argc, char **argv)
 		{0, 0, 0, 0}
 	};
 	(void)parseOptionsOrDie(argc, argv, options);
-	struct fragStats* sft = mapSharedDataOrDie(ftShm, O_RDONLY);
+	struct fragStats* sft = mapSharedDataOrDie(ftShm, O_RDONLY, NULL);
 	fragPrintStats(sft);
 	return 0;
 }


### PR DESCRIPTION
If a shm is altered while it is initiating the shm may bacome corrupted;
```
nfqlb init --ownfw=0 --shm=newshm --M=9973 --N=100 &
nfqlb activate --shm=newshm --index=50 102
# (may be accepted or cause an error printout)
```
Since the result is unpredictable there may be (and have been seen) a crash when traffic comes in.

This PR adds a validation of the shm. Example;
```
vm-002 ~ # nfqlb init --ownfw=0 --shm=newshm --M=9973 --N=100 &
vm-002 ~ # nfqlb activate --shm=newshm --index=50 102
Shm invalid; newshm
```
