### PR TITLE
Add Hash mode to hashKey

### DIFF
--- a/src/extension/cmdXlb.c
+++ b/src/extension/cmdXlb.c
@@ -38,7 +38,7 @@ static int packetHandleFn(
 {
 	struct ctKey key;
 	uint64_t fragid;
-	int rc = getHashKey(&key, 0, &fragid, proto, data, len);
+	int rc = getHashKey(&key, 0, &fragid, proto, data, len, 1);
 	if (rc < 0)
 		return -1;
 	unsigned hash = hashKeyAddresses(&key);

--- a/src/lib/iputils.h
+++ b/src/lib/iputils.h
@@ -27,15 +27,15 @@ int ipv6IsExtensionHeader(unsigned htype);
  */
 int getHashKey(
 	struct ctKey* key, unsigned short udpencap, uint64_t* fragid,
-	unsigned proto, void const* data, unsigned len);
+	unsigned proto, void const* data, unsigned len, unsigned short hash_mode);
 
 // Hash on addresses only
 unsigned hashKeyAddresses(struct ctKey* key);
 
 // The default hash function.
-// Hashes on the entire key, unless proto=sctp in which case we hash on
-// ports only.
-unsigned hashKey(struct ctKey* key);
+// Hashes on the entire key with hash_mode set to 0. With hash_mode 
+// set to 1 and proto=sctp, we hash on ports only.
+unsigned hashKey(struct ctKey* key, unsigned short hash_mode);
 
 /*
   parseAddress parses an address into a struct sockaddr_storage.

--- a/src/lib/test/pcap-test.c
+++ b/src/lib/test/pcap-test.c
@@ -88,9 +88,9 @@ cmdParse(int argc, char* argv[])
 		struct Packet* p = packets + i;
 		struct ctKey key;
 		uint64_t fragid;
-		rc = getHashKey(&key, 0, &fragid, p->protocol, p->data, p->len);
+		rc = getHashKey(&key, 0, &fragid, p->protocol, p->data, p->len, 1);
 		if (rc & 1) {
-			hash = hashKey(&key);
+			hash = hashKey(&key, 1);
 			key.id = fragid;
 			rc = handleFirstFragment(ft, &now, &key, hash, p->data, p->len);
 		} else if (rc & 2) {


### PR DESCRIPTION
Add hash mode setting for lb, flowlb and fwmark to configure the hashing algorithm.
The legacy hash is kept by default: tuple-5 and ports only for SCTP. A new one has been added to have tuple-5 for any protocol.
Fixes: #19