### PR TITLE
Get rid of permutation table in dynamic Maglev

### DIFF
--- a/src/lib/maglevdyn.h
+++ b/src/lib/maglevdyn.h
@@ -2,8 +2,7 @@
 
 struct MagDataDyn {
 	unsigned M, N;
-	int *lookup;
-	unsigned** permutation;
+	int* lookup;
 	int* active;
 };
 
@@ -25,9 +24,20 @@ void magDataDyn_init(unsigned M, unsigned N, void* mem, unsigned len);
   Must call magDataDyn_free() to free allocated memory.
  */
 void magDataDyn_map(struct MagDataDyn* m, void* mem);
-void magDataDyn_free(struct MagDataDyn* m);
 
 /*
   Call when the "active" array is updated
  */
 void magDataDyn_populate(struct MagDataDyn* m);
+
+
+// This is equivalent to
+// currentValue - skip >= 0 ? currentValue - skip : currentValue - skip + mod
+// but much faster than any conditional branching. In fact, this is as fast
+// as retrieving the values from a pre-computed table.
+static inline int compute_next_element_in_permutation(int currentValue, int skip, int mod)
+{
+	int v = currentValue - skip;
+	v += mod & ((v >= 0) - 1);
+	return v;
+}

--- a/src/nfqlb/cmdFlowLb.c
+++ b/src/nfqlb/cmdFlowLb.c
@@ -411,7 +411,6 @@ STATIC void loadbalancerRelease(struct LoadBalancer* lb)
 		munmap(lb->st, statbuf.st_size);
 		close(lb->fd);
 		free(lb->target);
-		magDataDyn_free(&lb->magd);
 		free(lb);
 	}
 }

--- a/src/nfqlb/cmdShm.c
+++ b/src/nfqlb/cmdShm.c
@@ -128,7 +128,6 @@ static int cmdShow(int argc, char **argv)
 			printf(" %d(%d)", magd.active[i], i);
 	}
 	printf("\n");
-	magDataDyn_free(&magd);
 
 	return 0;
 }


### PR DESCRIPTION
Fixes #18

This change gets rid of the huge permutation table. It turns out that the necessary values can be computed just as fast on the fly: there's no need to retrieve them from memory.
Another modification is that nfqlb (de)activate computes the new lookup table in a temporary array and copies the results to the actual lookup table in shared memory only when the Maglev computation is done: this makes sure that the loadbalancer does not throw away packets while Maglev computation is taking place.

This PR changes only the dynamic Maglev computation: the static Maglev parts (which are used only for reference) still use the old permutation table-based method.

Attached is a graph about the overall speedup achieved in the <b>populate</b> function. The proposed new method creates an equivalent lookup table.
![speedup](https://github.com/Nordix/nfqueue-loadbalancer/assets/172371296/76e4cf22-dd0d-4f9e-b022-4db5d8d15194)

As you see, the new method is faster until we have about 60 targets or so.